### PR TITLE
deps: use latest oras to upload assets to ghcr.io

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -40,14 +40,9 @@ jobs:
           username: ${{ env.GH_USER }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install oras
-        run: |
-          # oras was rollbacked to v0.12.0, because now v0.13.0 (the latest version) contains bugs: https://github.com/oras-project/oras/issues/447
-          curl -LO https://github.com/oras-project/oras/releases/download/v0.12.0/oras_0.12.0_linux_amd64.tar.gz
-          tar -xvf ./oras_0.12.0_linux_amd64.tar.gz
-          ./oras version
       - name: Upload assets to GHCR
         run: |
-          ./oras push ghcr.io/${{ github.repository }}:${DB_VERSION} \
-          --manifest-config /dev/null:application/vnd.aquasec.trivy.config.v1+json \
+          oras version
+          oras push ghcr.io/${{ github.repository }}:${DB_VERSION} \
+          --config /dev/null:application/vnd.aquasec.trivy.config.v1+json \
           db.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip


### PR DESCRIPTION
## Description
use latest oras to upload assets to ghcr.io

Test run - https://github.com/DmitriyLewen/trivy-java-db/actions/runs/4050964675/jobs/6968841390