### PR TITLE
refactor: rename db.tar.gz to javadb.tar.gz

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -31,7 +31,7 @@ jobs:
         run: make db-compress
 
       - name: Move DB
-        run: mv cache/trivy-java-db/db.tar.gz .
+        run: mv cache/trivy-java-db/javadb.tar.gz .
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v1
@@ -45,4 +45,4 @@ jobs:
           oras version
           oras push ghcr.io/${{ github.repository }}:${DB_VERSION} \
           --config /dev/null:application/vnd.aquasec.trivy.config.v1+json \
-          db.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
+          javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ cache/*: trivy-java-db
 
 .PHONY: db-compress
 db-compress: cache/*
-	tar cvzf cache/trivy-java-db/db.tar.gz -C cache/trivy-java-db/ trivy-java.db metadata.json
+	tar cvzf cache/trivy-java-db/javadb.tar.gz -C cache/trivy-java-db/ trivy-java.db metadata.json
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -4,4 +4,20 @@
 `trivy-java-db` parses all indexes from [maven repository](https://repo.maven.apache.org/maven2) and stores `ArtifactID`, `GroupID`, `Version` and `sha1` for jar files to SQlite DB.
 
 The DB is used in Trivy to discover information about `jars` without GAV inside them.
- 
+
+## Update interval
+Every Thursday in 00:00
+
+## Download the java indexes database
+You can download the actual compiled database via [Oras CLI](https://oras.land/cli/).
+
+oras >= v0.13.0:
+```sh
+$ oras pull ghcr.io/aquasecurity/trivy-java-db:1
+```
+
+oras < v0.13.0:
+```sh
+$ oras pull -a ghcr.io/aquasecurity/trivy-java-db:1
+```
+The database can be used for [Air-Gapped Environment](https://aquasecurity.github.io/trivy/latest/docs/advanced/air-gap/).


### PR DESCRIPTION
## Description
Trivy-db and Trivy-java-db have same archive names.
We need to separate them.