### PR TITLE
chore: db optimization to get GAV faster by Artifact_id and file_type

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -63,8 +63,11 @@ func (db *DB) Init() error {
 		return xerrors.Errorf("unable to create 'indices' table: %w", err)
 	}
 
-	if _, err := db.client.Exec("CREATE UNIQUE INDEX artifacts_idx ON artifacts(group_id, artifact_id)"); err != nil {
+	if _, err := db.client.Exec("CREATE UNIQUE INDEX artifacts_idx ON artifacts(artifact_id, group_id)"); err != nil {
 		return xerrors.Errorf("unable to create 'artifacts_idx' index: %w", err)
+	}
+	if _, err := db.client.Exec("CREATE INDEX indices_artifact_idx ON indices(artifact_id)"); err != nil {
+		return xerrors.Errorf("unable to create 'indices_artifact_idx' index: %w", err)
 	}
 	if _, err := db.client.Exec("CREATE UNIQUE INDEX indices_sha1_idx ON indices(sha1)"); err != nil {
 		return xerrors.Errorf("unable to create 'indices_sha1_idx' index: %w", err)

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -2,6 +2,7 @@ package db_test
 
 import (
 	"encoding/hex"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -124,8 +125,8 @@ func TestSelectIndexesByArtifactIDAndFileType(t *testing.T) {
 			artifactID:  "jstl",
 			archiveType: types.JarType,
 			want: []types.Index{
-				indexJstl,
 				indexJavaxServlet,
+				indexJstl,
 			},
 		},
 		{
@@ -148,6 +149,10 @@ func TestSelectIndexesByArtifactIDAndFileType(t *testing.T) {
 			require.NoError(t, err)
 
 			got, err := dbc.SelectIndexesByArtifactIDAndFileType(tt.artifactID, tt.archiveType)
+			sort.Slice(got, func(i, j int) bool {
+				return got[i].GroupID < got[j].GroupID
+			})
+
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})


### PR DESCRIPTION
## Description
- Create `indices_artifact_idx`.
- Swap `artifact_id` and `group_id` for `artifacts_idx`.

## Related Issues
- [ ] Close #12 
- [ ] Close aquasecurity/trivy/issues/3608 