### PR TITLE
update oras push syntax to fix issue with 0 length config

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -49,6 +49,6 @@ jobs:
       - name: Upload assets to GHCR
         run: |
           oras version
-          oras push ghcr.io/${{ github.repository }}:${DB_VERSION} \
-          --config /dev/null:application/vnd.aquasec.trivy.config.v1+json \
+          oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json \
+          ghcr.io/${{ github.repository }}:${DB_VERSION} \
           javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip


### PR DESCRIPTION
This pull request updates the syntax used to push the OCI artifact. Using /dev/null as the source for the config results in a zero (0) length blob, this causes an error when using `oras copy` to copy the artifact to another v2 API registry. Using the new `--artifact-type` parameter creates a config of the given type, containing an empty json object `{}`, and allows for the artifact to be copied successfully.

This change is necessary to allow the trivy java db OCI artifact to be copied to a registry hosted on an air-gapped network.