### PR TITLE
refactor(crawler): increase the number of retry to 10

### DIFF
--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -41,6 +41,7 @@ type Option struct {
 
 func NewCrawler(opt Option) Crawler {
 	client := retryablehttp.NewClient()
+	client.RetryMax = 50
 	client.Logger = nil
 
 	if opt.RootUrl == "" {

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -41,7 +41,7 @@ type Option struct {
 
 func NewCrawler(opt Option) Crawler {
 	client := retryablehttp.NewClient()
-	client.RetryMax = 50
+	client.RetryMax = 10
 	client.Logger = nil
 
 	if opt.RootUrl == "" {


### PR DESCRIPTION
## Description
Maven repository may be unstable.
Therefore, we need to increase the number of retries to avoid stopping the crawler.

Test run - https://github.com/DmitriyLewen/trivy-java-db/actions/runs/7987277853/job/21809424402

## Related Issues
- Close #25