### PR TITLE
feat(crawler): add canceled context to Visit func

### DIFF
--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -124,7 +124,7 @@ loop:
 func (c *Crawler) Visit(ctx context.Context, url string) error {
 	req, err := retryablehttp.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return xerrors.Errorf("unable to new HTTp request: %w", err)
+		return xerrors.Errorf("unable to new HTTP request: %w", err)
 	}
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -224,7 +224,7 @@ func (c *Crawler) crawlSHA1(ctx context.Context, baseURL string, meta *Metadata)
 func (c *Crawler) parseMetadata(ctx context.Context, url string) (*Metadata, error) {
 	req, err := retryablehttp.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, xerrors.Errorf("unable to new HTTp request: %w", err)
+		return nil, xerrors.Errorf("unable to new HTTP request: %w", err)
 	}
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -252,7 +252,7 @@ func (c *Crawler) parseMetadata(ctx context.Context, url string) (*Metadata, err
 func (c *Crawler) fetchSHA1(ctx context.Context, url string) ([]byte, error) {
 	req, err := retryablehttp.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, xerrors.Errorf("unable to new HTTp request: %w", err)
+		return nil, xerrors.Errorf("unable to new HTTP request: %w", err)
 	}
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -122,61 +122,61 @@ loop:
 }
 
 func (c *Crawler) Visit(ctx context.Context, url string) error {
-	select {
-	// Context can be canceled if we receive an error from another Visit function.
-	case <-ctx.Done():
-		return nil
-	default:
-		resp, err := c.http.Get(url)
+	resp, err := c.http.Get(url)
+	if err != nil {
+		return xerrors.Errorf("http get error (%s): %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	d, err := goquery.NewDocumentFromReader(resp.Body)
+	if err != nil {
+		return xerrors.Errorf("can't create new goquery doc: %w", err)
+	}
+
+	var children []string
+	var foundMetadata bool
+	d.Find("a").Each(func(i int, selection *goquery.Selection) {
+		link := selection.Text()
+		if link == "maven-metadata.xml" {
+			foundMetadata = true
+			return
+		} else if link == "../" || !strings.HasSuffix(link, "/") {
+			// only `../` and dirs have `/` suffix. We don't need to check other files.
+			return
+		}
+
+		children = append(children, link)
+	})
+
+	if foundMetadata {
+		meta, err := c.parseMetadata(url + "maven-metadata.xml")
 		if err != nil {
-			return xerrors.Errorf("http get error (%s): %w", url, err)
+			return xerrors.Errorf("metadata parse error: %w", err)
 		}
-		defer resp.Body.Close()
-
-		d, err := goquery.NewDocumentFromReader(resp.Body)
-		if err != nil {
-			return xerrors.Errorf("can't create new goquery doc: %w", err)
+		if meta != nil {
+			if err = c.crawlSHA1(url, meta); err != nil {
+				return err
+			}
+			// Return here since there is no need to crawl dirs anymore.
+			return nil
 		}
+	}
 
-		var children []string
-		var foundMetadata bool
-		d.Find("a").Each(func(i int, selection *goquery.Selection) {
-			link := selection.Text()
-			if link == "maven-metadata.xml" {
-				foundMetadata = true
+	c.wg.Add(len(children))
+
+	go func() {
+		for _, child := range children {
+			select {
+			// Context can be canceled if we receive an error from another Visit function.
+			case <-ctx.Done():
 				return
-			} else if link == "../" || !strings.HasSuffix(link, "/") {
-				// only `../` and dirs have `/` suffix. We don't need to check other files.
-				return
-			}
-
-			children = append(children, link)
-		})
-
-		if foundMetadata {
-			meta, err := c.parseMetadata(url + "maven-metadata.xml")
-			if err != nil {
-				return xerrors.Errorf("metadata parse error: %w", err)
-			}
-			if meta != nil {
-				if err = c.crawlSHA1(url, meta); err != nil {
-					return err
-				}
-				// Return here since there is no need to crawl dirs anymore.
-				return nil
-			}
-		}
-
-		c.wg.Add(len(children))
-
-		go func() {
-			for _, child := range children {
+			default:
 				c.urlCh <- url + child
 			}
-		}()
+		}
+	}()
 
-		return nil
-	}
+	return nil
 }
 
 func (c *Crawler) crawlSHA1(baseURL string, meta *Metadata) error {

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -63,8 +63,8 @@ func NewCrawler(opt Option) Crawler {
 
 func (c *Crawler) Crawl(ctx context.Context) error {
 	log.Println("Crawl maven repository and save indexes")
-	ctx, ctxCancelFunc := context.WithCancel(ctx)
-	defer ctxCancelFunc()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	errCh := make(chan error)
 	defer close(errCh)
@@ -111,7 +111,7 @@ loop:
 		case <-crawlDone:
 			break loop
 		case err := <-errCh:
-			ctxCancelFunc() // Stop all running Visit functions to avoid writing to closed c.urlCh.
+			cancel() // Stop all running Visit functions to avoid writing to closed c.urlCh.
 			close(c.urlCh)
 			return err
 


### PR DESCRIPTION
## Description
When we get error from `Visit` function we close `c.urlCh`.
But there are cases when another `Visit` function tries to write to `c.urlCh` before we return error.
In this case we get `panic` instead of error.
e.g. - https://github.com/aquasecurity/trivy-java-db/actions/runs/8041756834/job/21961450007#step:5:619

To avoid this case - we need to add context with `cancel` function for `Visit` function.