### PR TITLE
fix(crawl): skip 404 errors

### DIFF
--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -142,7 +142,7 @@ func (c *Crawler) Visit(ctx context.Context, url string) error {
 	defer resp.Body.Close()
 
 	// There are cases when url doesn't exist
-	// e.g. https://repo.maven.apache.org/maven2/io/springboot/ai/
+	// e.g. https://repo.maven.apache.org/maven2/io/springboot/ai/spring-ai-anthropic/
 	if resp.StatusCode != http.StatusOK {
 		return nil
 	}

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -141,6 +141,12 @@ func (c *Crawler) Visit(ctx context.Context, url string) error {
 	}
 	defer resp.Body.Close()
 
+	// There are cases when url doesn't exist
+	// e.g. https://repo.maven.apache.org/maven2/io/springboot/ai/
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+
 	d, err := goquery.NewDocumentFromReader(resp.Body)
 	if err != nil {
 		return xerrors.Errorf("can't create new goquery doc: %w", err)

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -23,7 +23,7 @@ import (
 	"github.com/aquasecurity/trivy-java-db/pkg/types"
 )
 
-const mavenRepoURL = "https://repo.maven.apache.org/maven2/io/springboot/ai/"
+const mavenRepoURL = "https://repo.maven.apache.org/maven2/"
 
 type Crawler struct {
 	dir  string

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -23,7 +23,7 @@ import (
 	"github.com/aquasecurity/trivy-java-db/pkg/types"
 )
 
-const mavenRepoURL = "https://repo.maven.apache.org/maven2/"
+const mavenRepoURL = "https://repo.maven.apache.org/maven2/io/springboot/ai/"
 
 type Crawler struct {
 	dir  string
@@ -306,6 +306,12 @@ func (c *Crawler) parseMetadata(ctx context.Context, url string) (*Metadata, err
 		return nil, xerrors.Errorf("http get error (%s): %w", url, err)
 	}
 	defer resp.Body.Close()
+
+	// There are cases when metadata.xml file doesn't exist
+	// e.g. https://repo.maven.apache.org/maven2/io/springboot/ai/spring-ai-vertex-ai-gemini-spring-boot-starter/maven-metadata.xml
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil
+	}
 
 	var meta Metadata
 	if err = xml.NewDecoder(resp.Body).Decode(&meta); err != nil {


### PR DESCRIPTION
## Description
There are cases when:
- url doesn't exists (e.g. https://repo.maven.apache.org/maven2/io/springboot/ai/spring-ai-anthropic/)
- metadata.xml file doesn't exist (e.g. https://repo.maven.apache.org/maven2/io/springboot/ai/spring-ai-vertex-ai-gemini-spring-boot-starter/maven-metadata.xml).

We should skip them to avoid error:
https://github.com/aquasecurity/trivy-java-db/actions/runs/9143589157/job/25140432050

## Related Issues
- Close #31 