### PR TITLE
fix: delete "Retry-After" in HTTP response

### DIFF
--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/httputil"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -49,6 +50,21 @@ func NewCrawler(opt Option) Crawler {
 	client.RetryMax = 10
 	client.Logger = slog.Default()
 	client.RetryWaitMin = 10 * time.Second
+	client.Backoff = func(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
+		// Maven Central returns "Retry-After: 0" for some reason, resulting in an immediate retry.
+		if resp.Header.Get("Retry-After") == "0" {
+			resp.Header.Del("Retry-After")
+		}
+		return retryablehttp.DefaultBackoff(min, max, attemptNum, resp)
+	}
+	client.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
+		if resp.StatusCode != http.StatusOK {
+			b, _ := httputil.DumpResponse(resp, false)
+			slog.Error("HTTP error", slog.String("url", resp.Request.URL.String()), slog.Int("num_tries", numTries),
+				slog.Int("status_code", resp.StatusCode), slog.String("header", string(b)))
+		}
+		return resp, err
+	}
 
 	if opt.RootUrl == "" {
 		opt.RootUrl = mavenRepoURL

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"net/http/httputil"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -59,9 +58,8 @@ func NewCrawler(opt Option) Crawler {
 	}
 	client.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
 		if resp.StatusCode != http.StatusOK {
-			b, _ := httputil.DumpResponse(resp, false)
 			slog.Error("HTTP error", slog.String("url", resp.Request.URL.String()), slog.Int("num_tries", numTries),
-				slog.Int("status_code", resp.StatusCode), slog.String("header", string(b)))
+				slog.Int("status_code", resp.StatusCode))
 		}
 		return resp, err
 	}


### PR DESCRIPTION
## Description
Our HTTP client doesn't sleep correctly between retries due to `Retry-After: 0` in the HTTP response from Maven Central. If this value is correct, an immediate retry should succeed, but in practice, it will return' 429 Too Many Requests` again. This value is most likely a mistake on the server side, so on our side, we ignore it and sleep as pre-configured.

```
HTTP/2.0 429 Too Many Requests
Content-Length: 47
Accept-Ranges: bytes
Content-Type: text/plain
Date: Wed, 25 Sep 2024 19:17:34 GMT
Retry-After: 0
Server: Varnish
Via: 1.1 varnish
X-Cache: MISS
X-Cache-Hits: 0
X-Served-By: cache-iad-kcgs7200042-IAD
X-Timer: S1727291855.653967,VS0,VE1
```