### PR TITLE
feat: add jitter for retries

### DIFF
--- a/cmd/trivy-java-db/main.go
+++ b/cmd/trivy-java-db/main.go
@@ -57,7 +57,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&cacheDir, "cache-dir", filepath.Join(userCacheDir, "trivy-java-db"),
 		"cache dir")
-	rootCmd.PersistentFlags().IntVar(&limit, "limit", 1000, "max parallelism")
+	rootCmd.PersistentFlags().IntVar(&limit, "limit", 300, "max parallelism")
 
 	rootCmd.AddCommand(crawlCmd)
 	rootCmd.AddCommand(buildCmd)

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -48,8 +48,8 @@ func NewCrawler(opt Option) Crawler {
 	client := retryablehttp.NewClient()
 	client.RetryMax = 10
 	client.Logger = slog.Default()
-	client.RetryWaitMin = 10 * time.Second
-	client.RetryWaitMax = 1 * time.Minute
+	client.RetryWaitMin = 1 * time.Minute
+	client.RetryWaitMax = 5 * time.Minute
 	client.Backoff = retryablehttp.LinearJitterBackoff
 	client.ResponseLogHook = func(_ retryablehttp.Logger, resp *http.Response) {
 		if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
## Description
Currently, if an HTTP request fails, all requests are retried after waiting for the same period of time. This can cause further 429 errors as many requests are issued at the same time again. To mitigate this, this PR introduces a random wait time (jitter).

```
024/09/26 06:35:32 ERROR HTTP error url=https://repo.maven.apache.org/maven2/com/amazonaws/aws-java-sdk-workmailmessageflow/1.11.724/ num_tries=11 status_code=429
2024/09/26 06:35:32 ERROR HTTP error url=https://repo.maven.apache.org/maven2/org/apache/servicemix/bundles/org.apache.servicemix.bundles.asm-2.2.3/1.0.0-rc1/ num_tries=11 status_code=429
2024/09/26 06:35:32 ERROR HTTP error url=https://repo.maven.apache.org/maven2/io/quarkus/quarkus-jdbc-h2-parent/1.4.1.Final/ num_tries=11 status_code=429
2024/09/26 06:35:32 ERROR HTTP error url=https://repo.maven.apache.org/maven2/org/apache/spark/spark-launcher_2.11/1.6.2/ num_tries=11 status_code=429
2024/09/26 06:35:32 ERROR HTTP error url=https://repo.maven.apache.org/maven2/dev/reformator/stacktracedecoroutinator/ num_tries=11 status_code=429
2024/09/26 06:35:32 ERROR HTTP error url=https://repo.maven.apache.org/maven2/aws/sdk/kotlin/m2-jvm/1.2.1/ num_tries=11 status_code=429
2024/09/26 06:35:32 ERROR HTTP error url=https://repo.maven.apache.org/maven2/org/cdk8s/cdk8s/1.10.107/ num_tries=11 status_code=429
2024/09/26 06:35:32 ERROR HTTP error url=https://repo.maven.apache.org/maven2/com/amazonaws/aws-java-sdk-networkmanager/1.12.570/ num_tries=11 status_code=429
2024/09/26 06:35:32 ERROR HTTP error url=https://repo.maven.apache.org/maven2/com/amazonaws/aws-java-sdk-sns/1.11.267/ num_tries=11 status_code=429
2024/09/26 06:35:32 ERROR HTTP error url=https://repo.maven.apache.org/maven2/software/amazon/awssdk/organizations/2.21.26/ num_tries=11 status_code=429
2024/09/26 06:35:32 ERROR HTTP error url=https://repo.maven.apache.org/maven2/software/amazon/awssdk/savingsplans/2.17.182/ num_tries=11 status_code=429
2024/09/26 06:35:32 ERROR HTTP error url=https://repo.maven.apache.org/maven2/org/apache/struts/struts2-gxp-plugin/2.5.10.1/ num_tries=11 status_code=429
2024/09/26 06:35:32 ERROR HTTP error url=https://repo.maven.apache.org/maven2/org/apache/geronimo/gshell/support/gshell-support/ num_tries=11 status_code=429
2024/09/26 06:35:32 ERROR HTTP error url=https://repo.maven.apache.org/maven2/software/amazon/awssdk/wellarchitected/2.16.46/ num_tries=11 status_code=429
2024/09/26 06:35:32 ERROR HTTP error url=https://repo.maven.apache.org/maven2/org/apache/shardingsphere/elasticjob/elasticjob-lite-lifecycle/3.0.4/ num_tries=11 status_code=429
```

## Rationale
Since [LinearJitterBackoff](https://github.com/hashicorp/go-retryablehttp/blob/40b0cad1633fd521cee5884724fcf03d039aaf3f/client.go#L619-L639) doesn't respect `Retry-After`, we don't need to delete the header anymore.
