### PR TITLE
ci(cron): install `oras` v1.2.0 in a separate step

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   build:
     name: Build DB
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -53,6 +53,11 @@ jobs:
           username: ${{ secrets.ECR_ACCESS_KEY_ID }}
           password: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
 
+      - name: Install oras
+        run: |
+          curl -LO https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz
+          tar -xvf ./oras_1.2.0_linux_amd64.tar.gz          
+
       - name: Upload assets to GHCR and ECR Public
         run: |
           lowercase_repo=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Upload assets to GHCR and ECR Public
         run: |
           lowercase_repo=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          oras version
+          ./oras version
           
           # Define an array of registry base URLs
           registries=(
@@ -72,7 +72,7 @@ jobs:
           # Loop through each registry and push the artifact
           for registry in "${registries[@]}"; do
             full_registry_url="${registry}/${lowercase_repo}"
-            oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json \
+            ./oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json \
             "${full_registry_url}:${DB_VERSION}" \
             javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
           


### PR DESCRIPTION
## Description
GitHub now uses ubuntu-24.04 as latest version (https://github.com/actions/runner-images/pull/10687)
But `24.04` doesn't have `oras` pre-installed(https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md).
So we need to install `oras` manually.

test run(check only oras version):
- https://github.com/DmitriyLewen/trivy-java-db/actions/runs/11321684866/job/31481112732#step:7:25