### PR TITLE
refactor: add only new artifacts

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -24,6 +24,17 @@ jobs:
           go-version-file: go.mod
         id: go
 
+      - name: Install oras
+        run: |
+          curl -LO https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz
+          tar -xvf ./oras_1.2.0_linux_amd64.tar.gz 
+
+      - name: Pull trivy-java-db
+        run: |
+          mkdir -p ./cache/db
+          ./oras pull docker.io/aquasec/trivy-java-db:1
+          tar -xvf javadb.tar.gz -C ./cache/db
+
       - name: Build the binary
         run: make build
 
@@ -58,11 +69,6 @@ jobs:
           registry: public.ecr.aws
           username: ${{ secrets.ECR_ACCESS_KEY_ID }}
           password: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
-
-      - name: Install oras
-        run: |
-          curl -LO https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz
-          tar -xvf ./oras_1.2.0_linux_amd64.tar.gz          
 
       - name: Upload assets to registries
         run: |

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Pull trivy-java-db
         run: |
           mkdir -p ./cache/db
-          ./oras pull docker.io/aquasec/trivy-java-db:1
+          lowercase_repo=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          ./oras pull "ghcr.io/${lowercase_repo}:${DB_VERSION}"
           tar -xvf javadb.tar.gz -C ./cache/db
 
       - name: Build the binary

--- a/cmd/trivy-java-db/main.go
+++ b/cmd/trivy-java-db/main.go
@@ -79,6 +79,8 @@ func crawl(ctx context.Context) error {
 		}
 		// Decrease the date by one day to offset the time of database creation
 		opt.LastUpdate = t.AddDate(0, 0, -1)
+		slog.Info("Using 'UpdatedAt' field to skip already added artifacts",
+			slog.String("date", fmt.Sprintf("%d-%d-%d", opt.LastUpdate.Year(), opt.LastUpdate.Month(), opt.LastUpdate.Day())))
 	}
 
 	c := crawler.NewCrawler(opt)

--- a/cmd/trivy-java-db/main.go
+++ b/cmd/trivy-java-db/main.go
@@ -71,8 +71,9 @@ func crawl(ctx context.Context) error {
 		CacheDir: cacheDir,
 	}
 
-	if db.Exists(cacheDir) {
-		t, err := db.GetMetadataUpdatedAt(cacheDir)
+	dbDir := db.Dir(cacheDir)
+	if db.Exists(dbDir) {
+		t, err := db.GetMetadataUpdatedAt(dbDir)
 		if err != nil {
 			return xerrors.Errorf("unable to get metadata UpdatedAt time: %w", err)
 		}
@@ -89,7 +90,7 @@ func crawl(ctx context.Context) error {
 }
 
 func build() error {
-	dbDir := filepath.Join(cacheDir, "db")
+	dbDir := db.Dir(cacheDir)
 	slog.Info("Database", slog.String("path", dbDir))
 	dbc, err := db.New(dbDir)
 	if err != nil {

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -227,6 +227,9 @@ func (c *Crawler) Visit(ctx context.Context, url string) error {
 	return nil
 }
 
+// To avoid a large number of requests to the server, we should skip already saved artifacts (if the start date is specified).
+// P.S. We do not need to check for updates, since artifacts are immutable
+// see https://central.sonatype.org/publish/requirements/immutability
 func (c *Crawler) skipChildLink(selection *goquery.Selection) bool {
 	if c.lastUpdate.IsZero() {
 		return false

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -336,7 +336,11 @@ func (c *Crawler) sha1Urls(ctx context.Context, url string) ([]string, error) {
 		// Don't include sources, test, javadocs, scaladoc files
 		if strings.HasSuffix(link, ".jar.sha1") && !strings.HasSuffix(link, "sources.jar.sha1") &&
 			!strings.HasSuffix(link, "test.jar.sha1") && !strings.HasSuffix(link, "tests.jar.sha1") &&
-			!strings.HasSuffix(link, "javadoc.jar.sha1") && !strings.HasSuffix(link, "scaladoc.jar.sha1") {
+			!strings.HasSuffix(link, "javadoc.jar.sha1") && !strings.HasSuffix(link, "scaladoc.jar.sha1") &&
+			// There are cases when version dir doesn't have date
+			// So we should check date of sha1 file
+			// e.g. https://repo.maven.apache.org/maven2/ant-contrib/cpptasks/1.0b3/cpptasks-1.0b3.jar.sha1
+			!c.skipChildLink(selection) {
 			sha1URLs = append(sha1URLs, url+link)
 		}
 	})

--- a/pkg/crawler/crawler_test.go
+++ b/pkg/crawler/crawler_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -17,6 +18,7 @@ func TestCrawl(t *testing.T) {
 	tests := []struct {
 		name       string
 		limit      int64
+		lastUpdate time.Time
 		fileNames  map[string]string
 		goldenPath string
 		filePath   string
@@ -40,6 +42,22 @@ func TestCrawl(t *testing.T) {
 				"/maven2/abbot/abbot/1.4.0/abbot-1.4.0-lite.jar.sha1":   "testdata/happy/abbot-1.4.0-lite.jar.sha1",
 			},
 			goldenPath: "testdata/happy/abbot.json.golden",
+			filePath:   "indexes/abbot/abbot.json",
+		},
+		{
+			name:       "happy path with lastUpdate",
+			limit:      1,
+			lastUpdate: time.Date(2010, 01, 01, 01, 01, 01, 0, time.UTC),
+			fileNames: map[string]string{
+				"/maven2/":                                            "testdata/happy/index.html",
+				"/maven2/abbot/":                                      "testdata/happy/abbot.html",
+				"/maven2/abbot/abbot/":                                "testdata/happy/abbot_abbot.html",
+				"/maven2/abbot/abbot/maven-metadata.xml":              "testdata/happy/maven-metadata.xml",
+				"/maven2/abbot/abbot/1.4.0/":                          "testdata/happy/abbot_abbot_1.4.0.html",
+				"/maven2/abbot/abbot/1.4.0/abbot-1.4.0.jar.sha1":      "testdata/happy/abbot-1.4.0.jar.sha1",
+				"/maven2/abbot/abbot/1.4.0/abbot-1.4.0-lite.jar.sha1": "testdata/happy/abbot-1.4.0-lite.jar.sha1",
+			},
+			goldenPath: "testdata/happy/abbot-1.4.0.json.golden",
 			filePath:   "indexes/abbot/abbot.json",
 		},
 		{
@@ -77,9 +95,10 @@ func TestCrawl(t *testing.T) {
 
 			tmpDir := t.TempDir()
 			cl := crawler.NewCrawler(crawler.Option{
-				RootUrl:  ts.URL + "/maven2/",
-				Limit:    tt.limit,
-				CacheDir: tmpDir,
+				RootUrl:    ts.URL + "/maven2/",
+				Limit:      tt.limit,
+				CacheDir:   tmpDir,
+				LastUpdate: tt.lastUpdate,
 			})
 
 			err := cl.Crawl(context.Background())

--- a/pkg/crawler/testdata/happy/abbot-1.4.0.json.golden
+++ b/pkg/crawler/testdata/happy/abbot-1.4.0.json.golden
@@ -1,0 +1,15 @@
+{
+  "GroupID": "abbot",
+  "ArtifactID": "abbot",
+  "Versions": [
+    {
+      "Version": "1.4.0-lite",
+      "SHA1": "BUerA3Bor6ICaSW9lL+5/Pzsl2E="
+    },
+    {
+      "Version": "1.4.0",
+      "SHA1": "ojY2RqndBZVWM7RQAQtZohr4pCM="
+    }
+  ],
+  "ArchiveType": "jar"
+}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -27,8 +27,14 @@ func path(cacheDir string) string {
 	return filepath.Join(cacheDir, dbFileName)
 }
 
-func Reset(cacheDir string) error {
-	return os.RemoveAll(path(cacheDir))
+func Exists(cacheDir string) bool {
+	if _, err := os.Stat(path(cacheDir)); os.IsNotExist(err) {
+		return false
+	}
+	if _, err := os.Stat(metadataPath(cacheDir)); os.IsNotExist(err) {
+		return false
+	}
+	return true
 }
 
 func New(cacheDir string) (DB, error) {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -27,6 +27,10 @@ func path(cacheDir string) string {
 	return filepath.Join(cacheDir, dbFileName)
 }
 
+func Dir(cacheDir string) string {
+	return filepath.Join(cacheDir, "db")
+}
+
 func Exists(cacheDir string) bool {
 	if _, err := os.Stat(path(cacheDir)); os.IsNotExist(err) {
 		return false

--- a/pkg/db/metadata.go
+++ b/pkg/db/metadata.go
@@ -15,6 +15,10 @@ type Client struct {
 	path string
 }
 
+func metadataPath(cacheDir string) string {
+	return filepath.Join(cacheDir, metadataFile)
+}
+
 type Metadata struct {
 	Version      int `json:",omitempty"`
 	NextUpdate   time.Time
@@ -24,7 +28,7 @@ type Metadata struct {
 
 func NewMetadata(cacheDir string) Client {
 	return Client{
-		path: filepath.Join(cacheDir, metadataFile),
+		path: metadataPath(cacheDir),
 	}
 }
 
@@ -66,4 +70,13 @@ func (c *Client) Delete() error {
 		return xerrors.Errorf("unable to remove the metadata file: %w", err)
 	}
 	return nil
+}
+
+func GetMetadataUpdatedAt(cacheDir string) (time.Time, error) {
+	c := NewMetadata(cacheDir)
+	metadata, err := c.Get()
+	if err != nil {
+		return time.Time{}, xerrors.Errorf("unable to get metadata: %w", err)
+	}
+	return metadata.UpdatedAt, nil
 }


### PR DESCRIPTION
## Description
Recently, we’ve been encountering `too many requests` error more frequently (https://github.com/aquasecurity/trivy-java-db/actions/runs/12458901714). 
Increasing the number of parallel goroutines or reducing the delay between requests doesn't resolve the issue.

Therefore, this PR adds functionality to add only new artifacts to the database. The need for adding is determined using the `updateAt` field from the `cache/db/metadata.json` file (the date minus one day to account for the time needed to build the database).
If the `cache/db` dir is empty, the crawler will save all indexes.

Test runs:
1. add new artifacts from `2024-10-13` - https://github.com/DmitriyLewen/trivy-java-db/actions/runs/12465006507/job/34790062252
2. add new artifacts from `2024-12-22` - https://github.com/DmitriyLewen/trivy-java-db/actions/runs/12465457228/job/34791277401