### PR TITLE
ci/cd: Upload artifacts to Aqua registry

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,9 +1,8 @@
 ---
 name: Trivy Java DB
 on:
-  push:
-    branches:
-      - lihiz_upload_to_aqua
+  schedule:
+    - cron: "0 0 * * *" # update indexes every day in 00:00
   workflow_dispatch:
 env:
   GH_USER: aqua-bot
@@ -16,49 +15,49 @@ jobs:
     name: Build DB
     runs-on: ubuntu-24.04
     steps:
-#      - name: Check out code into the Go module directory
-#        uses: actions/checkout@v2
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
 
-#      - name: Set up Go
-#        uses: actions/setup-go@v3
-#        with:
-#          go-version-file: go.mod
-#        id: go
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+        id: go
 
-#      - name: Build the binary
-#        run: make build
+      - name: Build the binary
+        run: make build
 
-#      - name: Crawl indexes
-#        run: make db-crawl
-#
-#      - name: Build database
-#        run: make db-build
-#
-#      - name: Compress database
-#        run: make db-compress
-#
-#      - name: Move DB
-#        run: mv cache/db/javadb.tar.gz .
+      - name: Crawl indexes
+        run: make db-crawl
 
-#      - name: Login to Docker Hub
-#        uses: docker/login-action@v3
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USER }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build database
+        run: make db-build
 
-#      - name: Login to GitHub Packages Container registry
-#        uses: docker/login-action@v3
-#        with:
-#          registry: ghcr.io
-#          username: ${{ env.GH_USER }}
-#          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compress database
+        run: make db-compress
 
-#      - name: Login to ECR
-#        uses: docker/login-action@v3
-#        with:
-#          registry: public.ecr.aws
-#          username: ${{ secrets.ECR_ACCESS_KEY_ID }}
-#          password: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
+      - name: Move DB
+        run: mv cache/db/javadb.tar.gz .
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Packages Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ env.GH_USER }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to ECR
+        uses: docker/login-action@v3
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.ECR_ACCESS_KEY_ID }}
+          password: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
 
       - name: login to Aqua Container Registry
         uses: azure/docker-login@v2
@@ -81,9 +80,17 @@ jobs:
           
           # Define an array of registry base URLs and their corresponding repository names
           declare -A registries=(
+            ["ghcr.io"]="${lowercase_repo}"
+            ["public.ecr.aws"]="${lowercase_repo}"
+            ["docker.io"]="${lowercase_repo}"
             ["${{ secrets.AQUSEC_ACR_REGISTRY_NAME }}"]=$(echo "$lowercase_repo" | cut -d'/' -f2)
           )
           
+          # Special case for docker.io if the organization is 'aquasecurity'
+          if [[ "${lowercase_repo}" == "aquasecurity/"* ]]; then
+            registries["docker.io"]="aquasec/${lowercase_repo#aquasecurity/}"
+            echo "Docker Hub repository adjusted for aquasecurity: ${registries["docker.io"]}"
+          fi
           
           # Loop through each registry and push the artifact
           for registry in "${!registries[@]}"; do
@@ -91,7 +98,9 @@ jobs:
             full_registry_url="${registry}/${repo_name}"
             echo "Processing registry: ${full_registry_url}"
         
-            if ./oras copy docker.io/aquasec/trivy-java-db:1 "${full_registry_url}:${DB_VERSION}"; then
+            if ./oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json \
+              "${full_registry_url}:${DB_VERSION}" \
+              javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip; then
               echo "Successfully pushed to ${full_registry_url}:${DB_VERSION}"
             else
               echo "Failed to push to ${full_registry_url}:${DB_VERSION}"
@@ -102,14 +111,14 @@ jobs:
           echo "Artifact upload process completed."
 
 
-#      - name: Microsoft Teams Notification
-#        ## Until the PR with the fix for the AdaptivCard version is merged yet
-#        ## https://github.com/Skitionek/notify-microsoft-teams/pull/96
-#        ## Use the aquasecurity fork
-#        uses: aquasecurity/notify-microsoft-teams@master
-#        if: failure()
-#        with:
-#          webhook_url: ${{ secrets.TRIVY_MSTEAMS_WEBHOOK }}
-#          needs: ${{ toJson(needs) }}
-#          job: ${{ toJson(job) }}
-#          steps: ${{ toJson(steps) }}
+      - name: Microsoft Teams Notification
+        ## Until the PR with the fix for the AdaptivCard version is merged yet
+        ## https://github.com/Skitionek/notify-microsoft-teams/pull/96
+        ## Use the aquasecurity fork
+        uses: aquasecurity/notify-microsoft-teams@master
+        if: failure()
+        with:
+          webhook_url: ${{ secrets.TRIVY_MSTEAMS_WEBHOOK }}
+          needs: ${{ toJson(needs) }}
+          job: ${{ toJson(job) }}
+          steps: ${{ toJson(steps) }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -84,11 +84,6 @@ jobs:
             ["${{ secrets.AQUSEC_ACR_REGISTRY_NAME }}"]=$(echo "$lowercase_repo" | cut -d'/' -f2)
           )
           
-          # Special case for docker.io if the organization is 'aquasecurity'
-          if [[ "${lowercase_repo}" == "aquasecurity/"* ]]; then
-            registries["docker.io"]="aquasec/${lowercase_repo#aquasecurity/}"
-            echo "Docker Hub repository adjusted for aquasecurity: ${registries["docker.io"]}"
-          fi
           
           # Loop through each registry and push the artifact
           for registry in "${!registries[@]}"; do

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -40,11 +40,11 @@ jobs:
 #      - name: Move DB
 #        run: mv cache/db/javadb.tar.gz .
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#      - name: Login to Docker Hub
+#        uses: docker/login-action@v3
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USER }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
 #      - name: Login to GitHub Packages Container registry
 #        uses: docker/login-action@v3

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -16,35 +16,35 @@ jobs:
     name: Build DB
     runs-on: ubuntu-24.04
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+#      - name: Check out code into the Go module directory
+#        uses: actions/checkout@v2
 
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: go.mod
-        id: go
-
-      - name: Build the binary
-        run: make build
-
-      - name: Crawl indexes
-        run: make db-crawl
-
-      - name: Build database
-        run: make db-build
-
-      - name: Compress database
-        run: make db-compress
-
-      - name: Move DB
-        run: mv cache/db/javadb.tar.gz .
-
-#      - name: Login to Docker Hub
-#        uses: docker/login-action@v3
+#      - name: Set up Go
+#        uses: actions/setup-go@v3
 #        with:
-#          username: ${{ secrets.DOCKERHUB_USER }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#          go-version-file: go.mod
+#        id: go
+
+#      - name: Build the binary
+#        run: make build
+
+#      - name: Crawl indexes
+#        run: make db-crawl
+#
+#      - name: Build database
+#        run: make db-build
+#
+#      - name: Compress database
+#        run: make db-compress
+#
+#      - name: Move DB
+#        run: mv cache/db/javadb.tar.gz .
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
 #      - name: Login to GitHub Packages Container registry
 #        uses: docker/login-action@v3
@@ -96,9 +96,7 @@ jobs:
             full_registry_url="${registry}/${repo_name}"
             echo "Processing registry: ${full_registry_url}"
         
-            if ./oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json \
-              "${full_registry_url}:${DB_VERSION}" \
-              javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip; then
+            if ./oras copy docker.io/aquasec/trivy-java-db:1 "${full_registry_url}:${DB_VERSION}"; then
               echo "Successfully pushed to ${full_registry_url}:${DB_VERSION}"
             else
               echo "Failed to push to ${full_registry_url}:${DB_VERSION}"

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,8 +1,9 @@
 ---
 name: Trivy Java DB
 on:
-  schedule:
-    - cron: "0 0 * * *" # update indexes every day in 00:00
+  push:
+    branches:
+      - lihiz_upload_to_aqua
   workflow_dispatch:
 env:
   GH_USER: aqua-bot
@@ -39,25 +40,32 @@ jobs:
       - name: Move DB
         run: mv cache/db/javadb.tar.gz .
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#      - name: Login to Docker Hub
+#        uses: docker/login-action@v3
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USER }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Login to GitHub Packages Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ env.GH_USER }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Login to GitHub Packages Container registry
+#        uses: docker/login-action@v3
+#        with:
+#          registry: ghcr.io
+#          username: ${{ env.GH_USER }}
+#          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to ECR
-        uses: docker/login-action@v3
+#      - name: Login to ECR
+#        uses: docker/login-action@v3
+#        with:
+#          registry: public.ecr.aws
+#          username: ${{ secrets.ECR_ACCESS_KEY_ID }}
+#          password: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
+
+      - name: login to Aqua Container Registry
+        uses: azure/docker-login@v2
         with:
-          registry: public.ecr.aws
-          username: ${{ secrets.ECR_ACCESS_KEY_ID }}
-          password: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
+          login-server: ${{ secrets.AQUSEC_ACR_REGISTRY_NAME }}
+          username: ${{ secrets.AQUASEC_ACR_USERNAME }}
+          password: ${{ secrets.AQUASEC_ACR_PASSWORD }}
 
       - name: Install oras
         run: |
@@ -73,9 +81,7 @@ jobs:
           
           # Define an array of registry base URLs and their corresponding repository names
           declare -A registries=(
-            ["ghcr.io"]="${lowercase_repo}"
-            ["public.ecr.aws"]="${lowercase_repo}"
-            ["docker.io"]="${lowercase_repo}"
+            ["${{ secrets.AQUSEC_ACR_REGISTRY_NAME }}"]=$(echo "$lowercase_repo" | cut -d'/' -f2)
           )
           
           # Special case for docker.io if the organization is 'aquasecurity'
@@ -103,14 +109,14 @@ jobs:
           echo "Artifact upload process completed."
 
 
-      - name: Microsoft Teams Notification
-        ## Until the PR with the fix for the AdaptivCard version is merged yet
-        ## https://github.com/Skitionek/notify-microsoft-teams/pull/96
-        ## Use the aquasecurity fork
-        uses: aquasecurity/notify-microsoft-teams@master
-        if: failure()
-        with:
-          webhook_url: ${{ secrets.TRIVY_MSTEAMS_WEBHOOK }}
-          needs: ${{ toJson(needs) }}
-          job: ${{ toJson(job) }}
-          steps: ${{ toJson(steps) }}
+#      - name: Microsoft Teams Notification
+#        ## Until the PR with the fix for the AdaptivCard version is merged yet
+#        ## https://github.com/Skitionek/notify-microsoft-teams/pull/96
+#        ## Use the aquasecurity fork
+#        uses: aquasecurity/notify-microsoft-teams@master
+#        if: failure()
+#        with:
+#          webhook_url: ${{ secrets.TRIVY_MSTEAMS_WEBHOOK }}
+#          needs: ${{ toJson(needs) }}
+#          job: ${{ toJson(job) }}
+#          steps: ${{ toJson(steps) }}


### PR DESCRIPTION
In order for internal and external users not to hit dockerhub rate limits, we need to upload opensource artifacts to aquasec as well upon releases.