### PR TITLE
fix: check artifacts in DB to reduce number of sha1 queries

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -24,6 +24,18 @@ jobs:
           go-version-file: go.mod
         id: go
 
+      - name: Install oras
+        run: |
+          curl -LO https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz
+          tar -xvf ./oras_1.2.0_linux_amd64.tar.gz 
+
+      - name: Pull trivy-java-db
+        run: |
+          mkdir -p ./cache/db
+          lowercase_repo=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          ./oras pull "ghcr.io/${lowercase_repo}:${DB_VERSION}"
+          tar -xvf javadb.tar.gz -C ./cache/db
+
       - name: Build the binary
         run: make build
 
@@ -58,11 +70,6 @@ jobs:
           registry: public.ecr.aws
           username: ${{ secrets.ECR_ACCESS_KEY_ID }}
           password: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
-
-      - name: Install oras
-        run: |
-          curl -LO https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz
-          tar -xvf ./oras_1.2.0_linux_amd64.tar.gz          
 
       - name: Upload assets to registries
         run: |

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -80,13 +80,14 @@ func NewCrawler(opt Option) (Crawler, error) {
 	slog.Info("Index dir", slog.String("path", indexDir))
 
 	var dbc db.DB
-	if db.Exists(opt.CacheDir) {
+	dbDir := db.Dir(opt.CacheDir)
+	if db.Exists(dbDir) {
 		var err error
-		dbc, err = db.New(opt.CacheDir)
+		dbc, err = db.New(dbDir)
 		if err != nil {
 			return Crawler{}, xerrors.Errorf("unable to open DB: %w", err)
 		}
-
+		slog.Info("DB is used for crawler", slog.String("path", opt.CacheDir))
 	}
 
 	return Crawler{

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -288,6 +288,11 @@ func (c *Crawler) crawlSHA1(ctx context.Context, baseURL string, meta *Metadata,
 			})
 		}
 
+		versions = lo.Filter(versions, func(v types.Version, _ int) bool {
+			_, ok := savedVersion[v.Version]
+			return !ok
+		})
+
 		foundVersions = append(foundVersions, versions...)
 	}
 

--- a/pkg/crawler/crawler_test.go
+++ b/pkg/crawler/crawler_test.go
@@ -2,15 +2,21 @@ package crawler_test
 
 import (
 	"context"
+	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/aquasecurity/trivy-java-db/pkg/dbtest"
+	"github.com/aquasecurity/trivy-java-db/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/trivy-java-db/pkg/crawler"
+
+	_ "modernc.org/sqlite"
 )
 
 func TestCrawl(t *testing.T) {
@@ -18,6 +24,7 @@ func TestCrawl(t *testing.T) {
 		name       string
 		limit      int64
 		fileNames  map[string]string
+		withDb     bool
 		goldenPath string
 		filePath   string
 		wantErr    string
@@ -25,6 +32,27 @@ func TestCrawl(t *testing.T) {
 		{
 			name:  "happy path",
 			limit: 1,
+			fileNames: map[string]string{
+				"/maven2/":                                              "testdata/happy/index.html",
+				"/maven2/abbot/":                                        "testdata/happy/abbot.html",
+				"/maven2/abbot/abbot/":                                  "testdata/happy/abbot_abbot.html",
+				"/maven2/abbot/abbot/maven-metadata.xml":                "testdata/happy/maven-metadata.xml",
+				"/maven2/abbot/abbot/0.12.3/":                           "testdata/happy/abbot_abbot_0.12.3.html",
+				"/maven2/abbot/abbot/0.12.3/abbot-0.12.3.jar.sha1":      "testdata/happy/abbot-0.12.3.jar.sha1",
+				"/maven2/abbot/abbot/0.13.0/":                           "testdata/happy/abbot_abbot_0.13.0.html",
+				"/maven2/abbot/abbot/0.13.0/abbot-0.13.0.jar.sha1":      "testdata/happy/abbot-0.13.0.jar.sha1",
+				"/maven2/abbot/abbot/0.13.0/abbot-0.13.0-copy.jar.sha1": "testdata/happy/abbot-0.13.0-copy.jar.sha1",
+				"/maven2/abbot/abbot/1.4.0/":                            "testdata/happy/abbot_abbot_1.4.0.html",
+				"/maven2/abbot/abbot/1.4.0/abbot-1.4.0.jar.sha1":        "testdata/happy/abbot-1.4.0.jar.sha1",
+				"/maven2/abbot/abbot/1.4.0/abbot-1.4.0-lite.jar.sha1":   "testdata/happy/abbot-1.4.0-lite.jar.sha1",
+			},
+			goldenPath: "testdata/happy/abbot.json.golden",
+			filePath:   "indexes/abbot/abbot.json",
+		},
+		{
+			name:   "happy path with DB",
+			withDb: true,
+			limit:  1,
 			fileNames: map[string]string{
 				"/maven2/":                                              "testdata/happy/index.html",
 				"/maven2/abbot/":                                        "testdata/happy/abbot.html",
@@ -76,13 +104,24 @@ func TestCrawl(t *testing.T) {
 			defer ts.Close()
 
 			tmpDir := t.TempDir()
-			cl := crawler.NewCrawler(crawler.Option{
+			if tt.withDb {
+				dbc, err := dbtest.InitDB(t, []types.Index{
+					indexAbbot123,
+					indexAbbot130,
+				})
+				require.NoError(t, err)
+
+				tmpDir = dbc.Dir()
+			}
+
+			cl, err := crawler.NewCrawler(crawler.Option{
 				RootUrl:  ts.URL + "/maven2/",
 				Limit:    tt.limit,
 				CacheDir: tmpDir,
 			})
+			require.NoError(t, err)
 
-			err := cl.Crawl(context.Background())
+			err = cl.Crawl(context.Background())
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
@@ -97,5 +136,24 @@ func TestCrawl(t *testing.T) {
 			assert.JSONEq(t, string(want), string(got))
 		})
 	}
-
 }
+
+var (
+	abbot123Sha1b, _ = hex.DecodeString("51d28a27d919ce8690a40f4f335b9d591ceb16e9")
+	indexAbbot123    = types.Index{
+		GroupID:     "abbot",
+		ArtifactID:  "abbot",
+		Version:     "0.12.3",
+		SHA1:        abbot123Sha1b,
+		ArchiveType: types.JarType,
+	}
+
+	abbot130Sha1b, _ = hex.DecodeString("596d91e67631b0deb05fb685d8d1b6735f3e4f60")
+	indexAbbot130    = types.Index{
+		GroupID:     "abbot",
+		ArtifactID:  "abbot",
+		Version:     "0.13.0",
+		SHA1:        abbot130Sha1b,
+		ArchiveType: types.JarType,
+	}
+)

--- a/pkg/crawler/crawler_test.go
+++ b/pkg/crawler/crawler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/aquasecurity/trivy-java-db/pkg/dbtest"
@@ -111,7 +112,7 @@ func TestCrawl(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				tmpDir = dbc.Dir()
+				tmpDir = filepath.Join(strings.TrimSuffix(dbc.Dir(), "db"))
 			}
 
 			cl, err := crawler.NewCrawler(crawler.Option{

--- a/pkg/crawler/crawler_test.go
+++ b/pkg/crawler/crawler_test.go
@@ -67,7 +67,7 @@ func TestCrawl(t *testing.T) {
 				"/maven2/abbot/abbot/1.4.0/abbot-1.4.0.jar.sha1":        "testdata/happy/abbot-1.4.0.jar.sha1",
 				"/maven2/abbot/abbot/1.4.0/abbot-1.4.0-lite.jar.sha1":   "testdata/happy/abbot-1.4.0-lite.jar.sha1",
 			},
-			goldenPath: "testdata/happy/abbot.json.golden",
+			goldenPath: "testdata/happy/abbot-with-db.json.golden",
 			filePath:   "indexes/abbot/abbot.json",
 		},
 		{

--- a/pkg/crawler/testdata/happy/abbot-with-db.json.golden
+++ b/pkg/crawler/testdata/happy/abbot-with-db.json.golden
@@ -1,0 +1,15 @@
+{
+  "GroupID": "abbot",
+  "ArtifactID": "abbot",
+  "Versions": [
+    {
+      "Version": "1.4.0-lite",
+      "SHA1": "BUerA3Bor6ICaSW9lL+5/Pzsl2E="
+    },
+    {
+      "Version": "1.4.0",
+      "SHA1": "ojY2RqndBZVWM7RQAQtZohr4pCM="
+    }
+  ],
+  "ArchiveType": "jar"
+}

--- a/pkg/crawler/testdata/happy/abbot_abbot_0.13.0.html
+++ b/pkg/crawler/testdata/happy/abbot_abbot_0.13.0.html
@@ -17,9 +17,9 @@ body {
 	<hr>
 	<main>
 		<pre id="contents"><a href="https://repo.maven.apache.org/maven2/abbot/abbot/">../</a>
-<a href="abbot-0.13.0-copy.jar" title="abbot-0.13.0.jar">abbot-0.13.0.jar</a>                                  2005-09-20 05:44    779426
-<a href="abbot-0.13.0-copy.jar.md5" title="abbot-0.13.0.jar.md5">abbot-0.13.0.jar.md5</a>                              2005-09-20 05:44        32
-<a href="abbot-0.13.0-copy.jar.sha1" title="abbot-0.13.0.jar.sha1">abbot-0.13.0.jar.sha1</a>                             2005-09-20 05:44        40
+<a href="abbot-0.13.0-copy.jar" title="abbot-0.13.0-copy.jar">abbot-0.13.0-copy.jar</a>                                  2005-09-20 05:44    779426
+<a href="abbot-0.13.0-copy.jar.md5" title="abbot-0.13.0-copy.jar.md5">abbot-0.13.0-copy.jar.md5</a>                              2005-09-20 05:44        32
+<a href="abbot-0.13.0-copy.jar.sha1" title="abbot-0.13.0-copy.jar.sha1">abbot-0.13.0-copy.jar.sha1</a>                             2005-09-20 05:44        40
 <a href="abbot-0.13.0.jar" title="abbot-0.13.0.jar">abbot-0.13.0.jar</a>                                  2005-09-20 05:44    779426      
 <a href="abbot-0.13.0.jar.md5" title="abbot-0.13.0.jar.md5">abbot-0.13.0.jar.md5</a>                              2005-09-20 05:44        32      
 <a href="abbot-0.13.0.jar.sha1" title="abbot-0.13.0.jar.sha1">abbot-0.13.0.jar.sha1</a>                             2005-09-20 05:44        40      

--- a/pkg/crawler/types.go
+++ b/pkg/crawler/types.go
@@ -18,10 +18,6 @@ type Versioning struct {
 type Index struct {
 	GroupID     string
 	ArtifactID  string
-	Versions    []Version
+	Versions    []types.Version
 	ArchiveType types.ArchiveType
-}
-type Version struct {
-	Version string
-	SHA1    []byte
 }

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -129,6 +129,54 @@ func TestSelectIndexByArtifactIDAndGroupID(t *testing.T) {
 	}
 }
 
+func TestSelectVersionsByArtifactIDAndGroupID(t *testing.T) {
+	tests := []struct {
+		name       string
+		groupID    string
+		artifactID string
+		want       map[string][]byte
+		assertErr  assert.ErrorAssertionFunc
+	}{
+		{
+			name:       "happy path",
+			groupID:    "javax.servlet",
+			artifactID: "jstl",
+			want: map[string][]byte{
+				"1.0":   javaxServlet10Sha1b,
+				"1.1.0": javaxServlet110Sha1b,
+			},
+			assertErr: assert.NoError,
+		},
+		{
+			name:       "wrong ArtifactID",
+			groupID:    "javax.servlet",
+			artifactID: "wrong",
+			want:       map[string][]byte{},
+			assertErr:  assert.NoError,
+		},
+		{
+			name:       "wrong GroupID",
+			groupID:    "wrong",
+			artifactID: "jstl",
+			want:       map[string][]byte{},
+			assertErr:  assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbc, err := dbtest.InitDB(t, []types.Index{
+				indexJavaxServlet10,
+				indexJavaxServlet11,
+			})
+			require.NoError(t, err)
+
+			got, err := dbc.SelectVersionsByArtifactIDAndGroupID(tt.artifactID, tt.groupID)
+			tt.assertErr(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestSelectIndexesByArtifactIDAndFileType(t *testing.T) {
 	var tests = []struct {
 		name        string

--- a/pkg/dbtest/dbtest.go
+++ b/pkg/dbtest/dbtest.go
@@ -1,16 +1,16 @@
 package dbtest
 
 import (
-	"github.com/aquasecurity/trivy-java-db/pkg/types"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/trivy-java-db/pkg/db"
+	"github.com/aquasecurity/trivy-java-db/pkg/types"
 )
 
 func InitDB(t *testing.T, indexes []types.Index) (db.DB, error) {
-	tmpDir := t.TempDir()
+	tmpDir := db.Dir(t.TempDir())
 	dbc, err := db.New(tmpDir)
 	require.NoError(t, err)
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -17,3 +17,8 @@ type Index struct {
 	SHA1        []byte
 	ArchiveType ArchiveType
 }
+
+type Version struct {
+	Version string
+	SHA1    []byte
+}


### PR DESCRIPTION
## Description
Recently, we’ve been encountering too many requests error more frequently (https://github.com/aquasecurity/trivy-java-db/actions/runs/12458901714).
So we need to check the version in the DB.
If the version for this artifact is already added - do not request sha1 for this version.

test builds:
- https://github.com/DmitriyLewen/trivy-java-db/actions/runs/12738972546
- https://github.com/DmitriyLewen/trivy-java-db/actions/runs/12729266847