### PR TITLE
refactor(crawler): set RetryMax to 15

### DIFF
--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -48,7 +48,7 @@ type Option struct {
 
 func NewCrawler(opt Option) (Crawler, error) {
 	client := retryablehttp.NewClient()
-	client.RetryMax = 10
+	client.RetryMax = 15
 	client.Logger = slog.Default()
 	client.RetryWaitMin = 1 * time.Minute
 	client.RetryWaitMax = 5 * time.Minute


### PR DESCRIPTION
## Description
lately we have been getting errors when building the database after 2-4 hours after 11 attempts
this PR increases the number of attempts to 15 (16) try to avoid these errors

examples:
- https://github.com/aquasecurity/trivy-java-db/actions/runs/13000929009
- https://github.com/aquasecurity/trivy-java-db/actions/runs/12979666316