### PR TITLE
ci(cron): disable teams alerts

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -108,16 +108,3 @@ jobs:
           done
           
           echo "Artifact upload process completed."
-
-
-      - name: Microsoft Teams Notification
-        ## Until the PR with the fix for the AdaptivCard version is merged yet
-        ## https://github.com/Skitionek/notify-microsoft-teams/pull/96
-        ## Use the aquasecurity fork
-        uses: aquasecurity/notify-microsoft-teams@master
-        if: failure()
-        with:
-          webhook_url: ${{ secrets.TRIVY_MSTEAMS_WEBHOOK }}
-          needs: ${{ toJson(needs) }}
-          job: ${{ toJson(job) }}
-          steps: ${{ toJson(steps) }}


### PR DESCRIPTION
## Description
We have a problem with trivy-java-db build.
We are trying to fix this issue (see https://github.com/aquasecurity/trivy-java-db/pull/52), but we don't have a good solution at the moment.

So we need to disable team notifications to avoid unnecessary noise.

