### PR TITLE
refactor(crawler): migrate to GCS

### DIFF
--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -11,6 +11,7 @@ import (
 	"math/rand"
 	"net/http"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -404,6 +405,10 @@ func (c *Crawler) crawlSHA1(ctx context.Context, groupID, artifactID string, dir
 	if len(foundVersions) == 0 {
 		return nil
 	}
+
+	slices.SortFunc(foundVersions, func(a, b types.Version) int {
+		return strings.Compare(a.Version, b.Version)
+	})
 
 	index := &Index{
 		GroupID:     groupID,

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -30,7 +30,7 @@ import (
 const (
 	mavenRepoURL = "https://repo.maven.apache.org/maven2/"
 	gcsRepoURL   = "https://storage.googleapis.com/maven-central/"
-	gcsApiURL    = "https://storage.googleapis.com/storage/v1/b/maven-central/o"
+	gcsApiURL    = "https://storage.googleapis.com/storage/v1/b/maven-central/o/"
 )
 
 type Crawler struct {
@@ -90,6 +90,10 @@ func NewCrawler(opt Option) (Crawler, error) {
 
 	if opt.GcsApiUrl == "" {
 		opt.GcsApiUrl = gcsApiURL
+	}
+
+	if opt.GcsRepoUrl == "" {
+		opt.GcsRepoUrl = gcsRepoURL
 	}
 
 	indexDir := filepath.Join(opt.CacheDir, "indexes")

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -163,6 +163,8 @@ func (c *Crawler) Crawl(ctx context.Context) error {
 				}
 			}(rootDir)
 		}
+
+		c.wg.Done() // Close first WG
 	}()
 
 loop:

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -111,9 +111,10 @@ func NewCrawler(opt Option) (Crawler, error) {
 	}
 
 	return Crawler{
-		dir:  indexDir,
-		http: client,
-		dbc:  &dbc,
+		dir:   indexDir,
+		http:  client,
+		dbc:   &dbc,
+		errCh: make(chan error),
 
 		mavenRepoURL: opt.MavenUrl,
 		gcrRepoURL:   opt.GcsRepoUrl,

--- a/pkg/crawler/crawler_test.go
+++ b/pkg/crawler/crawler_test.go
@@ -25,13 +25,6 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-type response struct {
-	Items []item `json:"items"`
-}
-type item struct {
-	Name string `json:"name"`
-}
-
 func TestCrawl(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/pkg/crawler/crawler_test.go
+++ b/pkg/crawler/crawler_test.go
@@ -3,106 +3,120 @@ package crawler_test
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/aquasecurity/trivy-java-db/pkg/dbtest"
 	"github.com/aquasecurity/trivy-java-db/pkg/types"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-java-db/pkg/crawler"
 
 	_ "modernc.org/sqlite"
 )
 
+type response struct {
+	Items []item `json:"items"`
+}
+type item struct {
+	Name string `json:"name"`
+}
+
 func TestCrawl(t *testing.T) {
 	tests := []struct {
-		name       string
-		limit      int64
-		fileNames  map[string]string
-		withDb     bool
-		goldenPath string
-		filePath   string
-		wantErr    string
+		name              string
+		limit             int64
+		maxResults        int
+		fileNames         map[string]string
+		withDb            bool
+		mavenCentralError bool
+		gcsApiError       bool
+		goldenPath        string
+		filePath          string
+		wantErr           string
 	}{
 		{
-			name:  "happy path",
-			limit: 1,
+			name:       "happy path",
+			limit:      2,
+			maxResults: 3,
 			fileNames: map[string]string{
-				"/maven2/":                                              "testdata/happy/index.html",
-				"/maven2/abbot/":                                        "testdata/happy/abbot.html",
-				"/maven2/abbot/abbot/":                                  "testdata/happy/abbot_abbot.html",
-				"/maven2/abbot/abbot/maven-metadata.xml":                "testdata/happy/maven-metadata.xml",
-				"/maven2/abbot/abbot/0.12.3/":                           "testdata/happy/abbot_abbot_0.12.3.html",
-				"/maven2/abbot/abbot/0.12.3/abbot-0.12.3.jar.sha1":      "testdata/happy/abbot-0.12.3.jar.sha1",
-				"/maven2/abbot/abbot/0.13.0/":                           "testdata/happy/abbot_abbot_0.13.0.html",
-				"/maven2/abbot/abbot/0.13.0/abbot-0.13.0.jar.sha1":      "testdata/happy/abbot-0.13.0.jar.sha1",
-				"/maven2/abbot/abbot/0.13.0/abbot-0.13.0-copy.jar.sha1": "testdata/happy/abbot-0.13.0-copy.jar.sha1",
-				"/maven2/abbot/abbot/1.4.0/":                            "testdata/happy/abbot_abbot_1.4.0.html",
-				"/maven2/abbot/abbot/1.4.0/abbot-1.4.0.jar.sha1":        "testdata/happy/abbot-1.4.0.jar.sha1",
-				"/maven2/abbot/abbot/1.4.0/abbot-1.4.0-lite.jar.sha1":   "testdata/happy/abbot-1.4.0-lite.jar.sha1",
+				"maven2/abbot/abbot/0.12.3/abbot-0.12.3.jar.sha1":      "testdata/happy/abbot-0.12.3.jar.sha1",
+				"maven2/abbot/abbot/0.13.0/abbot-0.13.0.jar.sha1":      "testdata/happy/abbot-0.13.0.jar.sha1",
+				"maven2/abbot/abbot/0.13.0/abbot-0.13.0-copy.jar.sha1": "testdata/happy/abbot-0.13.0-copy.jar.sha1",
+				"maven2/abbot/abbot/1.4.0/abbot-1.4.0.jar.sha1":        "testdata/happy/abbot-1.4.0.jar.sha1",
+				"maven2/abbot/abbot/1.4.0/abbot-1.4.0-lite.jar.sha1":   "testdata/happy/abbot-1.4.0-lite.jar.sha1",
 			},
 			goldenPath: "testdata/happy/abbot.json.golden",
 			filePath:   "indexes/abbot/abbot.json",
 		},
 		{
-			name:   "happy path with DB",
-			withDb: true,
-			limit:  1,
+			name:       "happy path with DB",
+			withDb:     true,
+			limit:      2,
+			maxResults: 3,
 			fileNames: map[string]string{
-				"/maven2/":                                              "testdata/happy/index.html",
-				"/maven2/abbot/":                                        "testdata/happy/abbot.html",
-				"/maven2/abbot/abbot/":                                  "testdata/happy/abbot_abbot.html",
-				"/maven2/abbot/abbot/maven-metadata.xml":                "testdata/happy/maven-metadata.xml",
-				"/maven2/abbot/abbot/0.12.3/":                           "testdata/happy/abbot_abbot_0.12.3.html",
-				"/maven2/abbot/abbot/0.12.3/abbot-0.12.3.jar.sha1":      "testdata/happy/abbot-0.12.3.jar.sha1",
-				"/maven2/abbot/abbot/0.13.0/":                           "testdata/happy/abbot_abbot_0.13.0.html",
-				"/maven2/abbot/abbot/0.13.0/abbot-0.13.0.jar.sha1":      "testdata/happy/abbot-0.13.0.jar.sha1",
-				"/maven2/abbot/abbot/0.13.0/abbot-0.13.0-copy.jar.sha1": "testdata/happy/abbot-0.13.0-copy.jar.sha1",
-				"/maven2/abbot/abbot/1.4.0/":                            "testdata/happy/abbot_abbot_1.4.0.html",
-				"/maven2/abbot/abbot/1.4.0/abbot-1.4.0.jar.sha1":        "testdata/happy/abbot-1.4.0.jar.sha1",
-				"/maven2/abbot/abbot/1.4.0/abbot-1.4.0-lite.jar.sha1":   "testdata/happy/abbot-1.4.0-lite.jar.sha1",
+				"maven2/abbot/abbot/0.12.3/abbot-0.12.3.jar.sha1":      "testdata/happy/abbot-0.12.3.jar.sha1",
+				"maven2/abbot/abbot/0.13.0/abbot-0.13.0.jar.sha1":      "testdata/happy/abbot-0.13.0.jar.sha1",
+				"maven2/abbot/abbot/0.13.0/abbot-0.13.0-copy.jar.sha1": "testdata/happy/abbot-0.13.0-copy.jar.sha1",
+				"maven2/abbot/abbot/1.4.0/abbot-1.4.0.jar.sha1":        "testdata/happy/abbot-1.4.0.jar.sha1",
+				"maven2/abbot/abbot/1.4.0/abbot-1.4.0-lite.jar.sha1":   "testdata/happy/abbot-1.4.0-lite.jar.sha1",
 			},
 			goldenPath: "testdata/happy/abbot-with-db.json.golden",
 			filePath:   "indexes/abbot/abbot.json",
 		},
 		{
-			name:  "sad path",
-			limit: 2,
-			fileNames: map[string]string{
-				// index.html file for this test contains many links to avoid case
-				// when we finish crawl and get error in one time.
-				// We will get a `panic` because we will try to close `urlCh` in 2 places (after the wait group and after the error)
-				// In real case it is impossible
-				"/maven2/":                               "testdata/sad/index.html",
-				"/maven2/abbot/":                         "testdata/sad/abbot.html",
-				"/maven2/abbot/abbot/":                   "testdata/sad/abbot_abbot.html",
-				"/maven2/abbot/abbot/maven-metadata.xml": "testdata/sad/maven-metadata.xml",
-				"/maven2/HTTPClient/":                    "testdata/sad/httpclient.html",
-				"/maven2/HTTPClient/HTTPClient/":         "testdata/sad/httpclient_httpclient.html",
-				"/maven2/HTTPClient/maven-metadata.xml":  "testdata/sad/maven-metadata.xml",
-			},
-			wantErr: "decode error:",
+			name:              "sad path. Maven central error",
+			limit:             2,
+			mavenCentralError: true,
+			wantErr:           "unable to get root dirs",
+		},
+		{
+			name:        "sad path. GCS API error",
+			limit:       2,
+			gcsApiError: true,
+			wantErr:     "HTTP request failed after retries",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				fileName, ok := tt.fileNames[r.URL.Path]
-				if !ok {
-					http.NotFound(w, r)
+			mts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.mavenCentralError {
+					w.WriteHeader(http.StatusInternalServerError)
 					return
 				}
-				http.ServeFile(w, r, fileName)
+				http.ServeFile(w, r, "testdata/happy/index.html")
 				w.WriteHeader(http.StatusOK)
 				return
 			}))
-			defer ts.Close()
+			defer mts.Close()
+
+			sha1List := lo.Keys(tt.fileNames)
+			slices.Sort(sha1List)
+
+			gts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasSuffix(r.URL.String(), ".jar.sha1") {
+					require.NoError(t, writeSha1(t, w, r, tt.fileNames))
+					return
+				}
+
+				if tt.gcsApiError {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				require.NoError(t, writeGCSResponse(t, w, r, sha1List, tt.maxResults))
+
+			}))
+			defer gts.Close()
 
 			tmpDir := t.TempDir()
 			if tt.withDb {
@@ -116,9 +130,11 @@ func TestCrawl(t *testing.T) {
 			}
 
 			cl, err := crawler.NewCrawler(crawler.Option{
-				RootUrl:  ts.URL + "/maven2/",
-				Limit:    tt.limit,
-				CacheDir: tmpDir,
+				MavenUrl:     mts.URL + "/maven2/",
+				GcsUrl:       gts.URL + "/",
+				Limit:        tt.limit,
+				CacheDir:     tmpDir,
+				WithoutRetry: true,
 			})
 			require.NoError(t, err)
 
@@ -137,6 +153,59 @@ func TestCrawl(t *testing.T) {
 			assert.JSONEq(t, string(want), string(got))
 		})
 	}
+}
+
+func writeSha1(t *testing.T, w http.ResponseWriter, r *http.Request, fileNames map[string]string) error {
+	t.Helper()
+	url := strings.TrimPrefix(r.URL.String(), "/maven-central/")
+	testFilePath, ok := fileNames[url]
+	if !ok {
+		return xerrors.Errorf("unable to find file: %s", r.URL.Path)
+	}
+	http.ServeFile(w, r, testFilePath)
+	w.WriteHeader(http.StatusOK)
+	return nil
+}
+
+func writeGCSResponse(t *testing.T, w http.ResponseWriter, r *http.Request, sha1Urls []string, maxResults int) error {
+	t.Helper()
+	var token int
+	q := r.URL.Query()
+	if qResult := q.Get("pageToken"); qResult != "" {
+		var err error
+		token, err = strconv.Atoi(qResult)
+		if err != nil {
+			return err
+		}
+	}
+
+	resp := crawler.GcsApiResponse{}
+
+	for i := token * maxResults; i < token*maxResults+maxResults; i++ {
+		resp.Items = append(resp.Items, crawler.Item{
+			Name: sha1Urls[i],
+		})
+
+		if i == len(sha1Urls)-1 {
+			token = -1
+		}
+	}
+	if token != -1 {
+		resp.NextPageToken = strconv.Itoa(token + 1)
+	}
+
+	jsonResp, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, err = w.Write(jsonResp)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 var (

--- a/pkg/crawler/testdata/happy/abbot-with-db.json.golden
+++ b/pkg/crawler/testdata/happy/abbot-with-db.json.golden
@@ -3,12 +3,12 @@
   "ArtifactID": "abbot",
   "Versions": [
     {
-      "Version": "1.4.0-lite",
-      "SHA1": "BUerA3Bor6ICaSW9lL+5/Pzsl2E="
-    },
-    {
       "Version": "1.4.0",
       "SHA1": "ojY2RqndBZVWM7RQAQtZohr4pCM="
+    },
+    {
+      "Version": "1.4.0-lite",
+      "SHA1": "BUerA3Bor6ICaSW9lL+5/Pzsl2E="
     }
   ],
   "ArchiveType": "jar"

--- a/pkg/crawler/testdata/happy/abbot.json.golden
+++ b/pkg/crawler/testdata/happy/abbot.json.golden
@@ -11,12 +11,12 @@
       "SHA1": "WW2R5nYxsN6wX7aF2NG2c18+T2A="
     },
     {
-      "Version": "1.4.0-lite",
-      "SHA1": "BUerA3Bor6ICaSW9lL+5/Pzsl2E="
-    },
-    {
       "Version": "1.4.0",
       "SHA1": "ojY2RqndBZVWM7RQAQtZohr4pCM="
+    },
+    {
+      "Version": "1.4.0-lite",
+      "SHA1": "BUerA3Bor6ICaSW9lL+5/Pzsl2E="
     }
   ],
   "ArchiveType": "jar"

--- a/pkg/crawler/types.go
+++ b/pkg/crawler/types.go
@@ -22,7 +22,7 @@ type Index struct {
 	ArchiveType types.ArchiveType
 }
 
-type gcsApiResponse struct {
+type GcsApiResponse struct {
 	NextPageToken string `json:"nextPageToken,omitempty"`
 	Items         []Item `json:"items,omitempty"`
 }

--- a/pkg/crawler/types.go
+++ b/pkg/crawler/types.go
@@ -21,3 +21,12 @@ type Index struct {
 	Versions    []types.Version
 	ArchiveType types.ArchiveType
 }
+
+type gcsApiResponse struct {
+	NextPageToken string `json:"nextPageToken,omitempty"`
+	Items         []Item `json:"items,omitempty"`
+}
+
+type Item struct {
+	Name string `json:"name"`
+}


### PR DESCRIPTION
## Description
Maven central changed tare limit.
We already can't build trivy-java-db.

To avoid this- we migrate to Google Cloud Storage (GCS) mirrors?

See https://github.com/aquasecurity/trivy-java-db/pull/52#issuecomment-2677658399 for more details