### PR TITLE
ci(cron): revert teams notifications

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -108,3 +108,13 @@ jobs:
           done
           
           echo "Artifact upload process completed."
+
+
+      - name: Microsoft Teams Notification
+        uses: Skitionek/notify-microsoft-teams@e7a2493ac87dad8aa7a62f079f295e54ff511d88
+        if: failure()
+        with:
+          webhook_url: ${{ secrets.TRIVY_MSTEAMS_WEBHOOK }}
+          needs: ${{ toJson(needs) }}
+          job: ${{ toJson(job) }}
+          steps: ${{ toJson(steps) }}


### PR DESCRIPTION
## Description 
We disabled `teams` notifications in #54.

After that we migrated to GCS (see #55).
So, the trivy-java-db build now works stable and we can enable notifications.