### PR TITLE
ci: update the cron workflow CI configuration

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -16,13 +16,12 @@ jobs:
     runs-on: ubuntu-2404-2core
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version-file: go.mod
-        id: go
 
       - name: Install oras
         run: |
@@ -33,7 +32,7 @@ jobs:
         run: make build
 
       - name: Clone maven-index repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           # Always use aquasecurity/maven-index as it's a private repository and cannot be forked.
           # Using ${github.repository_owner} would fail in forks as it doesn't exist there.
@@ -51,20 +50,20 @@ jobs:
         run: mv cache/db/javadb.tar.gz .
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Packages Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ghcr.io
           username: ${{ env.GH_USER }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to ECR
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: public.ecr.aws
           username: ${{ secrets.ECR_ACCESS_KEY_ID }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -39,7 +39,7 @@ jobs:
           # Using ${github.repository_owner} would fail in forks as it doesn't exist there.
           repository: aquasecurity/maven-index
           path: maven-index
-          token: ${{ secrets.ORG_REPO_TOKEN }}
+          token: ${{ secrets.MAVEN_INDEX_READ_TOKEN }}
 
       - name: Build database
         run: make db-build MAVEN_INDEX_DIR=maven-index

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
@@ -39,6 +41,7 @@ jobs:
           repository: aquasecurity/maven-index
           path: maven-index
           token: ${{ secrets.MAVEN_INDEX_READ_TOKEN }}
+          persist-credentials: false
 
       - name: Build database
         run: make db-build MAVEN_INDEX_DIR=maven-index

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   build:
     name: Build DB
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-2404-2core
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description
Updates the cron workflow CI configuration to use a dedicated runner and a more scoped access token.
## Changes 
  - Runner: Changed from ubuntu-24.04 (GitHub-hosted) to ubuntu-2404-2core (custom self-hosted runner)                                                                                                                                            
  - Token: Replaced ORG_REPO_TOKEN with MAVEN_INDEX_READ_TOKEN for checking out the aquasecurity/maven-index repository
