### PR TITLE
ci: use GitHub App token for maven-index checkout

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -33,6 +33,15 @@ jobs:
       - name: Build the binary
         run: make build
 
+      - name: Generate token for maven-index
+        id: maven-index-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.MAVEN_INDEX_READ_APP_ID }}
+          private-key: ${{ secrets.MAVEN_INDEX_READ_APP_PRIVATE_KEY }}
+          owner: aquasecurity
+          repositories: maven-index
+
       - name: Clone maven-index repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -40,7 +49,7 @@ jobs:
           # Using ${github.repository_owner} would fail in forks as it doesn't exist there.
           repository: aquasecurity/maven-index
           path: maven-index
-          token: ${{ secrets.MAVEN_INDEX_READ_TOKEN }}
+          token: ${{ steps.maven-index-token.outputs.token }}
           persist-credentials: false
 
       - name: Build database

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -37,7 +37,7 @@ jobs:
         id: maven-index-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.MAVEN_INDEX_READ_APP_ID }}
+          client-id: ${{ secrets.REPO_MAVEN_INDEX_READ_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.MAVEN_INDEX_READ_APP_PRIVATE_KEY }}
           owner: aquasecurity
           repositories: maven-index


### PR DESCRIPTION
## Description

Switch the `maven-index` checkout step in `cron.yml` from a long-lived Personal Access Token (`MAVEN_INDEX_READ_TOKEN`) to a short-lived installation token minted from a GitHub App via [`actions/create-github-app-token`][action].

The token is requested with the minimum scope needed for the job: read access to a single repository (`aquasecurity/maven-index`) under a single owner.

[action]: https://github.com/actions/create-github-app-token

## Changes

- Add a `Generate token for maven-index` step that exchanges the App credentials (`REPO_MAVEN_INDEX_READ_GH_APP_CLIENT_ID` + `MAVEN_INDEX_READ_APP_PRIVATE_KEY`) for an installation token, scoped to `aquasecurity/maven-index` only.
- Replace `token: ${{ secrets.MAVEN_INDEX_READ_TOKEN }}` in the `Clone maven-index repository` step with `token: ${{ steps.maven-index-token.outputs.token }}`.
- Use the `client-id` input (preferred) instead of the deprecated `app-id` input on `actions/create-github-app-token`.
- `actions/create-github-app-token` is pinned by SHA (`v3.1.1`), matching the existing convention for third-party actions in this workflow.

### Required secret changes (admin action needed)

- [x] **Add:** `REPO_MAVEN_INDEX_READ_GH_APP_CLIENT_ID`, `MAVEN_INDEX_READ_APP_PRIVATE_KEY` to repository secrets.
- [ ] **Remove (after merge):** `MAVEN_INDEX_READ_TOKEN` — no longer referenced.

## Test run

Verified end-to-end on a fork against a forked `maven-index` (checkout step succeeded): https://github.com/DmitriyLewen/trivy-java-db/actions/runs/25725796756/job/75538108621#step:7:1

